### PR TITLE
Resize the ui blocker

### DIFF
--- a/src/world/maps/draft_level_1.json
+++ b/src/world/maps/draft_level_1.json
@@ -685,8 +685,8 @@
                  "rotation":0,
                  "type":"",
                  "visible":true,
-                 "width":256,
-                 "x":384,
+                 "width":640,
+                 "x":192,
                  "y":512
                 }],
          "opacity":1,

--- a/src/world/maps/draft_level_2.json
+++ b/src/world/maps/draft_level_2.json
@@ -620,8 +620,8 @@
                  "rotation":0,
                  "type":"",
                  "visible":true,
-                 "width":256,
-                 "x":384,
+                 "width":640,
+                 "x":192,
                  "y":512
                 }],
          "opacity":1,

--- a/src/world/maps/draft_level_3.json
+++ b/src/world/maps/draft_level_3.json
@@ -678,8 +678,8 @@
                  "rotation":0,
                  "type":"",
                  "visible":true,
-                 "width":256,
-                 "x":384,
+                 "width":640,
+                 "x":192,
                  "y":512
                 }],
          "opacity":1,

--- a/src/world/maps/draft_level_4.json
+++ b/src/world/maps/draft_level_4.json
@@ -416,8 +416,8 @@
                  "rotation":0,
                  "type":"",
                  "visible":true,
-                 "width":256,
-                 "x":384,
+                 "width":640,
+                 "x":192,
                  "y":512
                 }],
          "opacity":1,

--- a/src/world/maps/draft_level_5.json
+++ b/src/world/maps/draft_level_5.json
@@ -521,8 +521,8 @@
                  "rotation":0,
                  "type":"",
                  "visible":true,
-                 "width":256,
-                 "x":384,
+                 "width":640,
+                 "x":192,
                  "y":512
                 }, 
                 {

--- a/src/world/maps/draft_level_secret_duck.json
+++ b/src/world/maps/draft_level_secret_duck.json
@@ -709,8 +709,8 @@
                  "rotation":0,
                  "type":"",
                  "visible":true,
-                 "width":256,
-                 "x":384,
+                 "width":640,
+                 "x":192,
                  "y":512
                 }],
          "opacity":1,

--- a/src/world/maps/draft_level_secret_penguin.json
+++ b/src/world/maps/draft_level_secret_penguin.json
@@ -543,8 +543,8 @@
                  "rotation":0,
                  "type":"",
                  "visible":true,
-                 "width":256,
-                 "x":384,
+                 "width":640,
+                 "x":192,
                  "y":512
                 }],
          "opacity":1,

--- a/src/world/maps/draft_level_secret_turtle.json
+++ b/src/world/maps/draft_level_secret_turtle.json
@@ -551,8 +551,8 @@
                  "rotation":0,
                  "type":"",
                  "visible":true,
-                 "width":256,
-                 "x":384,
+                 "width":640,
+                 "x":192,
                  "y":512
                 }],
          "opacity":1,


### PR DESCRIPTION
## Pull Request Documentation

### Refactor

- Resize ui blocker to prevent building under the tower selection ui

## Checklist

- [x] My code follows the code style of this project [How to use `black` autoformatter](https://github.com/psf/black#usage).
- [x] I have applied relevant labels and linked the PR to the relevant Issue.
